### PR TITLE
Add SDK generation and validation prompts

### DIFF
--- a/openapi-to-sdk/src/McpSamples.OpenAPItoSDK.HybridApp/Prompts/SdkGenerationPrompt.cs
+++ b/openapi-to-sdk/src/McpSamples.OpenAPItoSDK.HybridApp/Prompts/SdkGenerationPrompt.cs
@@ -10,18 +10,18 @@ public interface ISdkGenerationPrompt
     /// <summary>
     /// Gets a prompt for generating an SDK from an OpenAPI specification, including parsing Kiota options.
     /// </summary>
-    /// <param name="openApi">The location of the OpenAPI description.</param>
+    /// <param name="openApiDocUrl">The location of the OpenAPI description.</param>
     /// <param name="language">The target language for the SDK.</param>
     /// <param name="additionalOptions">Additional user-provided options for Kiota.</param>
     /// <returns>A formatted prompt for SDK generation with parsing instructions.</returns>
-    string GetSdkGenerationPrompt(string openApi, string language, string? additionalOptions = null);
+    string GetSdkGenerationPrompt(string openApiDocUrl, string language, string? additionalOptions = null);
 
     /// <summary>
     /// Gets a prompt for validating an OpenAPI specification.
     /// </summary>
-    /// <param name="openApi">The URL of the OpenAPI specification.</param>
+    /// <param name="openApiDocUrl">The URL of the OpenAPI specification.</param>
     /// <returns>A formatted prompt for validating the OpenAPI spec.</returns>
-    string GetValidationPrompt(string openApi);
+    string GetValidationPrompt(string openApiDocUrl);
 }
 
 /// <summary>
@@ -34,14 +34,14 @@ public class SdkGenerationPrompt : ISdkGenerationPrompt
     [McpServerPrompt(Name = "generate_sdk_with_parsing", Title = "Generate SDK from OpenAPI Spec with Kiota Parsing")]
     [Description("Provides a structured prompt for parsing Kiota options and generating an SDK.")]
     public string GetSdkGenerationPrompt(
-        [Description("The Location of the OpenAPI description.")] string openApi,
+        [Description("The Location of the OpenAPI description.")] string openApiDocUrl,
         [Description("The target language for the SDK.")] string language,
         [Description("Additional options for Kiota (e.g., '--namespace-name MyNamespace').")] string? additionalOptions = null)
     {
         return $"""
             Generate an SDK from the provided OpenAPI specification using Kiota.
 
-            OpenAPI Location: {openApi}
+            OpenAPI Location: {openApiDocUrl}
             Language: {language}
             Additional Options: {additionalOptions ?? "None"}
 
@@ -58,12 +58,12 @@ public class SdkGenerationPrompt : ISdkGenerationPrompt
     [McpServerPrompt(Name = "validate_openapi_spec", Title = "Validate OpenAPI Specification")]
     [Description("Provides a structured prompt for validating an OpenAPI specification before SDK generation.")]
     public string GetValidationPrompt(
-        [Description("The OpenAPI specification URL.")] string openApi)
+        [Description("The OpenAPI specification URL.")] string openApiDocUrl)
     {
         return $"""
             Validate the provided OpenAPI specification.
 
-            OpenAPI Location: {openApi}
+            OpenAPI Location: {openApiDocUrl}
 
             Instructions:
             - Download and parse the OpenAPI spec.

--- a/openapi-to-sdk/src/McpSamples.OpenAPItoSDK.HybridApp/Prompts/SdkGenerationPrompt.cs
+++ b/openapi-to-sdk/src/McpSamples.OpenAPItoSDK.HybridApp/Prompts/SdkGenerationPrompt.cs
@@ -1,0 +1,75 @@
+using ModelContextProtocol.Server;
+
+namespace McpSamples.OpenApiToSdk.HybridApp.Prompts;
+
+/// <summary>
+/// This provides interfaces for SDK generation prompts.
+/// </summary>
+public interface ISdkGenerationPrompt
+{
+    /// <summary>
+    /// Gets a prompt for generating an SDK from an OpenAPI specification, including parsing Kiota options.
+    /// </summary>
+    /// <param name="openApi">The location of the OpenAPI description.</param>
+    /// <param name="language">The target language for the SDK.</param>
+    /// <param name="additionalOptions">Additional user-provided options for Kiota.</param>
+    /// <returns>A formatted prompt for SDK generation with parsing instructions.</returns>
+    string GetSdkGenerationPrompt(string openApi, string language, string? additionalOptions = null);
+
+    /// <summary>
+    /// Gets a prompt for validating an OpenAPI specification.
+    /// </summary>
+    /// <param name="openApi">The URL of the OpenAPI specification.</param>
+    /// <returns>A formatted prompt for validating the OpenAPI spec.</returns>
+    string GetValidationPrompt(string openApi);
+}
+
+/// <summary>
+/// This provides prompts for SDK generation from OpenAPI specs.
+/// </summary>
+[McpServerPromptType]
+public class SdkGenerationPrompt : ISdkGenerationPrompt
+{
+    /// <inheritdoc />
+    [McpServerPrompt(Name = "generate_sdk_with_parsing", Title = "Generate SDK from OpenAPI Spec with Kiota Parsing")]
+    [Description("Provides a structured prompt for parsing Kiota options and generating an SDK.")]
+    public string GetSdkGenerationPrompt(
+        [Description("The Location of the OpenAPI description.")] string openApi,
+        [Description("The target language for the SDK.")] string language,
+        [Description("Additional options for Kiota (e.g., '--namespace-name MyNamespace').")] string? additionalOptions = null)
+    {
+        return $"""
+            Generate an SDK from the provided OpenAPI specification using Kiota.
+
+            OpenAPI Location: {openApi}
+            Language: {language}
+            Additional Options: {additionalOptions ?? "None"}
+
+            Instructions:
+            - Parse the additional options to valid Kiota command-line arguments.
+            - Use the 'generate_sdk' tool with the parsed options to process the spec.
+            - Validate the OpenAPI spec before generation.
+            - Return the ZIP file URI upon success.
+            - Handle errors gracefully and provide feedback.
+            """;
+    }
+
+    /// <inheritdoc />
+    [McpServerPrompt(Name = "validate_openapi_spec", Title = "Validate OpenAPI Specification")]
+    [Description("Provides a structured prompt for validating an OpenAPI specification before SDK generation.")]
+    public string GetValidationPrompt(
+        [Description("The OpenAPI specification URL.")] string openApi)
+    {
+        return $"""
+            Validate the provided OpenAPI specification.
+
+            OpenAPI Location: {openApi}
+
+            Instructions:
+            - Download and parse the OpenAPI spec.
+            - Check for syntax errors, missing required fields, and schema validity.
+            - Report any validation issues or confirm validity.
+            - Use this validation before proceeding to SDK generation.
+            """;
+    }
+}


### PR DESCRIPTION
ISdkGenerationPrompt 인터페이스와 SdkGenerationPrompt 클래스를 도입하여 OpenAPI 명세에서 SDK 생성 및 검증을 지원합니다.
SDK 생성과 OpenAPI 명세 검증을 프롬프트를 제공합니다.

아래의 Task에 해당합니다.

User Story 3.1: LLM 클라이언트로서, 나는 SDK 생성 기능을 쉽게 사용할 수 있도록 Pre-defined Prompt를 받고 싶다.
    - **Tasks**:
        - [ ] SDK 생성 요청(Tools)을 위한 Pre-defined Prompt 정의.