### PR TITLE
feat #88: add HybridApp setting files

### DIFF
--- a/onedrive-download/md_file/.gitignore
+++ b/onedrive-download/md_file/.gitignore
@@ -1,0 +1,1 @@
+feature.md

--- a/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/McpSamples.OneDriveDownloader.HybridApp.csproj
+++ b/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/McpSamples.OneDriveDownloader.HybridApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/Program.cs
+++ b/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/Properties/launchSettings.json
+++ b/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5285",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7273;http://localhost:5285",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/appsettings.Development.json
+++ b/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/appsettings.json
+++ b/onedrive-download/src/McpSamples.OneDriveDownloader.HybridApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
_outlook_email 파일 구조를 참조해 프로젝트 뼈대를 구조화하였습니다. (issue #88)_
* HybridApp.csproj
  기본적 웹 프로젝트 상태로 초기화. 프로젝트가 사용하는 닷넷 버전과 프로젝트 핵심 속성 정의 - 추후 Microsoft Graph와 같은 연동에 필요한 패키지 추가 예정
* appsettings.json
  애플리케이션 설정 담당하는 json 파일. 기존 outlook-email 구조를 참조했으나 API 관련 설정은 지우고 logging 등 기본적 설정만 left
* Program.cs
  애플리케이션의 시작점 역할. 파일은 현재 빈 상태고 추후 코드 추가 예정
