### PR TITLE
feat(awesome-azd): Implement core service logic

### DIFF
--- a/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
+++ b/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
@@ -1,6 +1,91 @@
 namespace McpSamples.AwesomeAzd.HybridApp.Services;
 
-public class TemplateService ()
+using System.Text.Json;
+using McpSamples.AwesomeAzd.HybridApp.Models;
+
+public class AwesomeAzdService(HttpClient http, ILogger<AwesomeAzdService> logger) : IAwesomeAzdService
 {
-    
+    private const string AwesomeAzdTemplateFileUrl = "https://raw.githubusercontent.com/Azure/awesome-azd/main/website/static/templates.json";
+
+    private List<AwesomeAzdTemplateModel>? _cachedTemplates;
+
+    public async Task<List<AwesomeAzdTemplateModel>> GetTemplateListAsync(string keywords, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(keywords))
+        {
+            return new List<AwesomeAzdTemplateModel>();
+        }
+
+        var templates = await GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
+
+        var searchTerms = keywords.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                                  .Select(term => term.Trim().ToLowerInvariant())
+                                  .Where(term => string.IsNullOrWhiteSpace(term) != true)
+                                  .ToArray();
+
+        logger.LogInformation("Search terms: {terms}", string.Join(", ", searchTerms));
+
+        var result = templates
+            .Where(t => ContainsAnyKeyword(t.Title, searchTerms)
+                    || ContainsAnyKeyword(t.Description, searchTerms)
+                    || ContainsAnyKeyword(t.Author, searchTerms)
+                    || ContainsAnyKeyword(t.Source, searchTerms)
+                    || (t.Tags?.Any(tag => ContainsAnyKeyword(tag, searchTerms)) ?? false)
+                    || (t.Languages?.Any(lang => ContainsAnyKeyword(lang, searchTerms)) ?? false)
+                    || (t.AzureServices?.Any(svc => ContainsAnyKeyword(svc, searchTerms)) ?? false))
+            .ToList();
+
+        _cachedTemplates = result;
+        return result;
+    }
+
+    private async Task<List<AwesomeAzdTemplateModel>> GetTemplatesAsync(CancellationToken cancellationToken)
+    {
+        if (_cachedTemplates != null && _cachedTemplates.Any())
+        {
+            return _cachedTemplates;
+        }
+
+        try
+        {
+            logger.LogInformation("Fetching templates from {url}", AwesomeAzdTemplateFileUrl);
+
+            var response = await http.GetAsync(AwesomeAzdTemplateFileUrl, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            _cachedTemplates = JsonSerializer.Deserialize<List<AwesomeAzdTemplateModel>>(json,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ?? new List<AwesomeAzdTemplateModel>();
+
+            logger.LogInformation("Loaded {count} templates.", _cachedTemplates.Count);
+            return _cachedTemplates;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to fetch or deserialize templates.");
+            return new List<AwesomeAzdTemplateModel>();
+        }
+    }
+
+    private static bool ContainsAnyKeyword(string? text, string[] searchTerms)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return searchTerms.Any(term => text.Contains(term, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    public Task<AwesomeAzdTemplateModel?> GetTemplateDetailByIdAsync(string id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<string> GetTemplateInitCommandAsync(string id)
+    {
+        throw new NotImplementedException();
+    }
+
 }


### PR DESCRIPTION
Service interface에서 정의한 3개의 task(GetTemplateListAsync, GetTemplateDetailByIdAsync, GetTemplateInitCommandAsync) 중 GetTemplateListAsync가 작동하도록 하여 service.cs를 구현하였습니다.

주어진 keyword를 띄어쓰기로 구분하여 keyword가 들어간 템플릿을 모두 가져옵니다.
이후에 사용할 수 있도록 우선 _cachedTemplate에 캐싱합니다.