### PR TITLE
fix(awesome-azd): delete command-making Task

### DIFF
--- a/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
+++ b/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
@@ -58,6 +58,7 @@ public class AwesomeAzdService(HttpClient http, ILogger<AwesomeAzdService> logge
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                 ?? new List<AwesomeAzdTemplateModel>();
 
+
             logger.LogInformation("Loaded {count} templates.", _cachedTemplates.Count);
             return _cachedTemplates;
         }
@@ -78,7 +79,7 @@ public class AwesomeAzdService(HttpClient http, ILogger<AwesomeAzdService> logge
         return searchTerms.Any(term => text.Contains(term, StringComparison.InvariantCultureIgnoreCase));
     }
 
-    public Task<AwesomeAzdTemplateModel?> GetTemplateDetailByIdAsync(string id)
+    public async Task<AwesomeAzdTemplateModel?> GetTemplateDetailByTitleAsync(string title, CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }

--- a/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
+++ b/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/AwesomeAzdService.cs
@@ -83,9 +83,4 @@ public class AwesomeAzdService(HttpClient http, ILogger<AwesomeAzdService> logge
         throw new NotImplementedException();
     }
 
-    public Task<string> GetTemplateInitCommandAsync(string id)
-    {
-        throw new NotImplementedException();
-    }
-
 }

--- a/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/IAwesomeAzdService.cs
+++ b/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/IAwesomeAzdService.cs
@@ -18,9 +18,10 @@ namespace McpSamples.AwesomeAzd.HybridApp.Services
         /// <summary>
         /// Retrieves template details from the cached template list obtained from <see cref="GetTemplateListAsync"/>.
         /// </summary>
-        /// <param name="id">The template ID to retrieve.</param>
-        /// <returns>The <see cref="AwesomeAzdTemplateModel"/> corresponding to the specified ID, or null if not found.</returns>
-        Task<AwesomeAzdTemplateModel?> GetTemplateDetailByIdAsync(string id);
+        /// <param name="title">The template Title to retrieve.</param>
+        /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+        /// <returns>The <see cref="AwesomeAzdTemplateModel"/> corresponding to the specified Title, or error Model if not found.</returns>
+        Task<AwesomeAzdTemplateModel?> GetTemplateDetailByTitleAsync(string title, CancellationToken cancellationToken = default);
 
     }
 }

--- a/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/IAwesomeAzdService.cs
+++ b/awesome-azd/src/McpSamples.AwesomeAzd.HybridApp/Services/IAwesomeAzdService.cs
@@ -22,11 +22,5 @@ namespace McpSamples.AwesomeAzd.HybridApp.Services
         /// <returns>The <see cref="AwesomeAzdTemplateModel"/> corresponding to the specified ID, or null if not found.</returns>
         Task<AwesomeAzdTemplateModel?> GetTemplateDetailByIdAsync(string id);
 
-        /// <summary>
-        /// Generates the azd init command for a specific template.
-        /// </summary>
-        /// <param name="id">The template ID for which to generate the command.</param>
-        /// <returns>A string containing the azd init command for the template.</returns>
-        Task<string> GetTemplateInitCommandAsync(string id);
     }
 }


### PR DESCRIPTION
1. 각 template의 실행 명령어를 만드는 Task를 Service에서 public class로 따로 구현하려 하였으나,
Prompt에서 실행 명령어를 상세히 설명하고 있기 때문에
기존 GetTemplateInitCommandAsync class를 삭제하였습니다.

2. 기존 Id를 인자로 템플릿의 detail을 불러오는 Task GetTemplateDetailByIdAsync 에서 id를 title로 변경하고 task이름을 변경하였습니다.